### PR TITLE
fix: リスト更新時のチャット通知を抑制

### DIFF
--- a/twitchchattranslator.js
+++ b/twitchchattranslator.js
@@ -571,13 +571,13 @@ function refreshList(category) {
 	    // ignoreline
 	    ignoreLine = '';
 	    ignoreLine = JSON.parse(fs.readFileSync(ignoreLineFile, 'utf8')).ignorelines;
-
+	
 	    if (!ignoreLine) {
 		logger.error("ERROR: can't reload " + ignoreLineFile);
-		sendChatMessage(target, "ERROR: can't reload ignoring line list");
+	    //	sendChatMessage(target, "ERROR: can't reload ignoring line list");
 	    } else {
 		logger.info("ignoring user list has been reloaded from " + ignoreLineFile);
-		sendChatMessage(target, 'ignoring line list has been reloaded from json file');
+	    //	sendChatMessage(target, 'ignoring line list has been reloaded from json file');
 	    }
 
 	    break;
@@ -589,10 +589,10 @@ function refreshList(category) {
 
 	    if (!ignoreUsers) {
 		logger.error("ERROR: can't reload " + iuJson);
-		sendChatMessage(target, "ERROR: can't reload ignoring user list");
+	    //	sendChatMessage(target, "ERROR: can't reload ignoring user list");
 	    } else {
 		logger.info("ignoring user list has been reloaded from " + iuJson);
-		sendChatMessage(target, 'ignoring user list has been reloaded from json file');
+	    //	sendChatMessage(target, 'ignoring user list has been reloaded from json file');
 	    }
 
 	    break;
@@ -602,13 +602,13 @@ function refreshList(category) {
 	    emotes = '';
 	    emotes = JSON.parse(fs.readFileSync(emoticonJson, 'utf8')).emoticons;
 
-	     if (!emotes) {
+	    if (!emotes) {
 		logger.error("ERROR: can't reload " + emoticonJson);
-		sendChatMessage(target, "ERROR: can't reload emoticons user list");
+	    //	sendChatMessage(target, "ERROR: can't reload emoticons user list");
 	    } else {
-		logger.info("emoticons list has been reloaded from " + emoticonJson);
-		sendChatMessage(target, 'emoticons list has been reloaded from json file');
-	     }
+		logger.info("ignoring user list has been reloaded from " + emoticonJson);
+	    //	sendChatMessage(target, 'emoticons list has been reloaded from json file');
+	    }
 
 	    break;
 


### PR DESCRIPTION
## 概要
リスト更新コマンド (`!refreshignoreuser`, `!refreshignoreline`, `!refreshemoticons`) 実行時にチャットへ通知メッセージが投稿されると、配信中の視聴者を混乱させる原因となる。

## 変更内容
`refreshList` 関数内の6箇所の `sendChatMessage()` 呼び出しをコメントアウト。エラーメッセージ・成功メッセージの両方が対象。

ログファイルへの記録は維持されるため、実行結果はサーバ側で確認可能。